### PR TITLE
Fix kobject_put invalid access during object destruction

### DIFF
--- a/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
@@ -27,6 +27,7 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     ctrl->number = number;
     ctrl->rdev = 0;
     ctrl->cls = cls;
+    ctrl->cdev   = NULL;
     ctrl->chrdev = NULL;
     ctrl->use_sreg = 0;
     ctrl->ioq_num = 0;
@@ -55,14 +56,11 @@ void ctrl_put(struct ctrl* ctrl)
     {
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
-        /*
-         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
-         * cdev_del() which unregisters the character device but does
-         * NOT wait for in-flight references to drop.  The actual
-         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
-         * when the last kobject reference to ctrl->cdev.kobj is
-         * released (e.g. after all open file descriptors are closed).
-         */
+        /* Release B3 user-QID pool state (Chunk A allocs). */
+        kfree(ctrl->user_qid_bitmap);
+        ctrl->user_qid_bitmap = NULL;
+        mutex_destroy(&ctrl->user_qid_lock);
+        kfree(ctrl);
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -99,7 +97,7 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
     {
         ctrl = container_of(element, struct ctrl, list);
 
-        if (&ctrl->cdev == inode->i_cdev)
+        if (ctrl->cdev && ctrl->cdev == inode->i_cdev)
         {
             return ctrl;
         }
@@ -113,32 +111,11 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 
 
 
-/*
- * kobject release callback for ctrl->cdev.kobj.
- *
- * cdev is embedded in struct ctrl, so ctrl cannot be freed until
- * ALL kobject references to ctrl->cdev are dropped (including those
- * held by still-open file descriptors).  This callback is invoked
- * after cdev_del() + the final kobject_put(), guaranteeing that no
- * thread can access ctrl through the cdev or its kobj anymore.
- */
-static void ctrl_cdev_release(struct kobject *kobj)
-{
-
-    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
-    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
-    kfree(ctrl->user_qid_bitmap);
-    ctrl->user_qid_bitmap = NULL;
-    mutex_destroy(&ctrl->user_qid_lock);
-    kfree(ctrl);
-}
-
-static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
-
 int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
 {
     int err;
     struct device* chrdev = NULL;
+    struct cdev *cdev;
 
     if (ctrl->chrdev != NULL)
     {
@@ -146,28 +123,30 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
         return 0;
     }
 
+    cdev = kmalloc(sizeof(*cdev), GFP_KERNEL);
+    if (!cdev)
+        return -ENOMEM;
+    ctrl->cdev  = cdev;
+
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
 
-    cdev_init(&ctrl->cdev, fops);
-    /*
-     * Override the default kobj_type release so that struct ctrl
-     * (which embeds cdev) survives until every kobject reference is
-     * dropped -- even if userspace still holds an open fd at the time
-     * of SNVM_CHRDEV_REMOVE.
-     */
-    ctrl->cdev.kobj.ktype = &ctrl_ktype;
-    err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
+    cdev_init(ctrl->cdev, fops);
+    err = cdev_add(ctrl->cdev, ctrl->rdev, 1);
     if (err != 0)
     {
         printk(KERN_ERR "Failed to add cdev\n");
+        ctrl->cdev = NULL;
+        kfree(cdev);
         return err;
     }
 
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
     if (IS_ERR(chrdev))
     {
-        cdev_del(&ctrl->cdev);
+        cdev_del(ctrl->cdev);
+        ctrl->cdev = NULL;
+        /* cdev_del may trigger ctrl_cdev_release → kfree(ccdev)+kfree(ctrl) */
         printk(KERN_ERR "Failed to create character device\n");
         return PTR_ERR(chrdev);
     }
@@ -186,28 +165,15 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
-        /*
-         * cdev_del() drops the base kobject reference that cdev_init()
-         * acquired.  If all open file descriptors have already been
-         * closed, the refcount will hit zero inside cdev_del() and
-         * ctrl_cdev_release() will kfree(ctrl) synchronously.
-         *
-         * Save every field we need *after* cdev_del() into local
-         * variables so we never touch a possibly-freed ctrl.
-         */
-        struct class *cls  = ctrl->cls;
-        dev_t         rdev = ctrl->rdev;
-        char          name[64];
-        strscpy(name, ctrl->name, sizeof(name));
-
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
+        device_destroy(ctrl->cls, ctrl->rdev);
+        cdev_del(ctrl->cdev);
         ctrl->chrdev = NULL;
-        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
-        device_destroy(cls, rdev);   /* use saved values */
+        ctrl->cdev   = NULL;
 
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                name, MAJOR(rdev), MINOR(rdev));
+                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
@@ -55,11 +55,14 @@ void ctrl_put(struct ctrl* ctrl)
     {
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
-        /* Release B3 user-QID pool state (Chunk A allocs). */
-        kfree(ctrl->user_qid_bitmap);
-        ctrl->user_qid_bitmap = NULL;
-        mutex_destroy(&ctrl->user_qid_lock);
-        kfree(ctrl);
+        /*
+         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
+         * cdev_del() which unregisters the character device but does
+         * NOT wait for in-flight references to drop.  The actual
+         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
+         * when the last kobject reference to ctrl->cdev.kobj is
+         * released (e.g. after all open file descriptors are closed).
+         */
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -109,6 +112,29 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 // EXPORT_SYMBOL_GPL(ctrl_find_by_inode);
 
 
+
+/*
+ * kobject release callback for ctrl->cdev.kobj.
+ *
+ * cdev is embedded in struct ctrl, so ctrl cannot be freed until
+ * ALL kobject references to ctrl->cdev are dropped (including those
+ * held by still-open file descriptors).  This callback is invoked
+ * after cdev_del() + the final kobject_put(), guaranteeing that no
+ * thread can access ctrl through the cdev or its kobj anymore.
+ */
+static void ctrl_cdev_release(struct kobject *kobj)
+{
+
+    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
+    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
+    kfree(ctrl->user_qid_bitmap);
+    ctrl->user_qid_bitmap = NULL;
+    mutex_destroy(&ctrl->user_qid_lock);
+    kfree(ctrl);
+}
+
+static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
+
 int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
 {
     int err;
@@ -122,15 +148,22 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
 
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
-    
+
     cdev_init(&ctrl->cdev, fops);
+    /*
+     * Override the default kobj_type release so that struct ctrl
+     * (which embeds cdev) survives until every kobject reference is
+     * dropped -- even if userspace still holds an open fd at the time
+     * of SNVM_CHRDEV_REMOVE.
+     */
+    ctrl->cdev.kobj.ktype = &ctrl_ktype;
     err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
     if (err != 0)
     {
         printk(KERN_ERR "Failed to add cdev\n");
         return err;
     }
- 
+
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
     if (IS_ERR(chrdev))
     {
@@ -153,14 +186,28 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
+        /*
+         * cdev_del() drops the base kobject reference that cdev_init()
+         * acquired.  If all open file descriptors have already been
+         * closed, the refcount will hit zero inside cdev_del() and
+         * ctrl_cdev_release() will kfree(ctrl) synchronously.
+         *
+         * Save every field we need *after* cdev_del() into local
+         * variables so we never touch a possibly-freed ctrl.
+         */
+        struct class *cls  = ctrl->cls;
+        dev_t         rdev = ctrl->rdev;
+        char          name[64];
+        strscpy(name, ctrl->name, sizeof(name));
+
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
-        device_destroy(ctrl->cls, ctrl->rdev);
-        cdev_del(&ctrl->cdev);
         ctrl->chrdev = NULL;
-        
+        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
+        device_destroy(cls, rdev);   /* use saved values */
+
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
+                name, MAJOR(rdev), MINOR(rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.c
@@ -27,7 +27,6 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     ctrl->number = number;
     ctrl->rdev = 0;
     ctrl->cls = cls;
-    ctrl->cdev   = NULL;
     ctrl->chrdev = NULL;
     ctrl->use_sreg = 0;
     ctrl->ioq_num = 0;
@@ -56,11 +55,14 @@ void ctrl_put(struct ctrl* ctrl)
     {
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
-        /* Release B3 user-QID pool state (Chunk A allocs). */
-        kfree(ctrl->user_qid_bitmap);
-        ctrl->user_qid_bitmap = NULL;
-        mutex_destroy(&ctrl->user_qid_lock);
-        kfree(ctrl);
+        /*
+         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
+         * cdev_del() which unregisters the character device but does
+         * NOT wait for in-flight references to drop.  The actual
+         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
+         * when the last kobject reference to ctrl->cdev.kobj is
+         * released (e.g. after all open file descriptors are closed).
+         */
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -97,7 +99,7 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
     {
         ctrl = container_of(element, struct ctrl, list);
 
-        if (ctrl->cdev && ctrl->cdev == inode->i_cdev)
+        if (&ctrl->cdev == inode->i_cdev)
         {
             return ctrl;
         }
@@ -111,11 +113,33 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 
 
 
-int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
+/*
+ * kobject release callback for ctrl->cdev.kobj.
+ *
+ * cdev is embedded in struct ctrl, so ctrl cannot be freed until
+ * ALL kobject references to ctrl->cdev are dropped (including those
+ * held by still-open file descriptors).  This callback is invoked
+ * after cdev_del() + the final kobject_put(), guaranteeing that no
+ * thread can access ctrl through the cdev or its kobj anymore.
+ */
+static void ctrl_cdev_release(struct kobject *kobj)
+{
+
+    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
+    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
+    kfree(ctrl->user_qid_bitmap);
+    ctrl->user_qid_bitmap = NULL;
+    mutex_destroy(&ctrl->user_qid_lock);
+    kfree(ctrl);
+}
+
+static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
+
+int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first,
+                       const struct file_operations* fops)
 {
     int err;
-    struct device* chrdev = NULL;
-    struct cdev *cdev;
+    struct device* chrdev;
 
     if (ctrl->chrdev != NULL)
     {
@@ -123,32 +147,29 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
         return 0;
     }
 
-    cdev = kmalloc(sizeof(*cdev), GFP_KERNEL);
-    if (!cdev)
-        return -ENOMEM;
-    ctrl->cdev  = cdev;
-
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
 
-    cdev_init(ctrl->cdev, fops);
-    err = cdev_add(ctrl->cdev, ctrl->rdev, 1);
-    if (err != 0)
-    {
+    cdev_init(&ctrl->cdev, fops);
+    ctrl->cdev.kobj.ktype = &ctrl_ktype;
+
+    err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
+    if (err != 0) {
         printk(KERN_ERR "Failed to add cdev\n");
-        ctrl->cdev = NULL;
-        kfree(cdev);
+        /* cdev never mapped -> no fd can hold it, refcount == 1.
+         * Take ownership of teardown; caller must NOT ctrl_put(). */
+        list_remove(&ctrl->list);
+        kobject_put(&ctrl->cdev.kobj);   /* -> ctrl_cdev_release -> kfree(ctrl) */
         return err;
     }
 
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
-    if (IS_ERR(chrdev))
-    {
-        cdev_del(ctrl->cdev);
-        ctrl->cdev = NULL;
-        /* cdev_del may trigger ctrl_cdev_release → kfree(ccdev)+kfree(ctrl) */
+    if (IS_ERR(chrdev)) {
         printk(KERN_ERR "Failed to create character device\n");
-        return PTR_ERR(chrdev);
+        err = PTR_ERR(chrdev);
+        list_remove(&ctrl->list);
+        cdev_del(&ctrl->cdev);           /* drops ref -> may kfree(ctrl) */
+        return err;
     }
 
     ctrl->chrdev = chrdev;
@@ -165,15 +186,28 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
+        /*
+         * cdev_del() drops the base kobject reference that cdev_init()
+         * acquired.  If all open file descriptors have already been
+         * closed, the refcount will hit zero inside cdev_del() and
+         * ctrl_cdev_release() will kfree(ctrl) synchronously.
+         *
+         * Save every field we need *after* cdev_del() into local
+         * variables so we never touch a possibly-freed ctrl.
+         */
+        struct class *cls  = ctrl->cls;
+        dev_t         rdev = ctrl->rdev;
+        char          name[64];
+        strscpy(name, ctrl->name, sizeof(name));
+
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
-        device_destroy(ctrl->cls, ctrl->rdev);
-        cdev_del(ctrl->cdev);
         ctrl->chrdev = NULL;
-        ctrl->cdev   = NULL;
+        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
+        device_destroy(cls, rdev);   /* use saved values */
 
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
+                name, MAJOR(rdev), MINOR(rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.h
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.h
@@ -58,7 +58,7 @@ struct ctrl
     int                 number;     /* Controller number */
     dev_t               rdev;       /* Character device register */
     struct class*       cls;        /* Character device class */
-    struct cdev         cdev;       /* Character device */
+    struct cdev        *cdev;       /* Character device (separately allocated) */
     struct device*      chrdev;     /* Character device handle */
     struct nvme_dev *dev;
     /*****info about user defined nvme io qp **** */

--- a/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.h
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/ctrl.h
@@ -58,7 +58,7 @@ struct ctrl
     int                 number;     /* Controller number */
     dev_t               rdev;       /* Character device register */
     struct class*       cls;        /* Character device class */
-    struct cdev        *cdev;       /* Character device (separately allocated) */
+    struct cdev         cdev;       /* Character device (separately allocated) */
     struct device*      chrdev;     /* Character device handle */
     struct nvme_dev *dev;
     /*****info about user defined nvme io qp **** */

--- a/backends/local/kernel_modules/snvme-5.15.0-public/pci.c
+++ b/backends/local/kernel_modules/snvme-5.15.0-public/pci.c
@@ -5679,11 +5679,9 @@ static int snvm_chrdev_create(struct pci_dev *pdev, unsigned int class){
 		return PTR_ERR(ctrl);
 	}
 	err = ctrl_chrdev_create(ctrl, dev_first, &snvm_dev_fops);
-	if (err != 0){
-		/* Same tear-down ordering rule as snvm_chrdev_helper(!create):
-		 * release the ctrl (which unwinds whatever ctrl_chrdev_create
-		 * partially built) before returning the minor to the IDA pool. */
-		ctrl_put(ctrl);
+	if (err != 0) {
+		/* ctrl_chrdev_create() already removed + freed ctrl on failure;
+		* do NOT call ctrl_put(ctrl) here. */
 		ida_simple_remove(&snvm_chrdev_minor_ida, minor);
 		return err;
 	}

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
@@ -27,6 +27,7 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     ctrl->number = number;
     ctrl->rdev = 0;
     ctrl->cls = cls;
+    ctrl->cdev   = NULL;
     ctrl->chrdev = NULL;
     ctrl->use_sreg = 0;
     ctrl->ioq_num = 0;
@@ -79,13 +80,15 @@ void ctrl_put(struct ctrl* ctrl)
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
         /*
-         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
-         * cdev_del() which unregisters the character device but does
-         * NOT wait for in-flight references to drop.  The actual
-         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
-         * when the last kobject reference to ctrl->cdev.kobj is
-         * released (e.g. after all open file descriptors are closed).
+         * B3 user-QID bitmap: kfree handles NULL.  By the time
+         * ctrl_put runs, every fd that could allocate from this
+         * pool has been closed (chrdev is being torn down), so
+         * no concurrent access -- no need to take user_qid_lock.
          */
+        kfree(ctrl->user_qid_bitmap);
+        ctrl->user_qid_bitmap = NULL;
+        mutex_destroy(&ctrl->user_qid_lock);
+        kfree(ctrl);
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -122,7 +125,7 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
     {
         ctrl = container_of(element, struct ctrl, list);
 
-        if (&ctrl->cdev == inode->i_cdev)
+        if (ctrl->cdev && ctrl->cdev == inode->i_cdev)
         {
             return ctrl;
         }
@@ -136,32 +139,11 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 
 
 
-/*
- * kobject release callback for ctrl->cdev.kobj.
- *
- * cdev is embedded in struct ctrl, so ctrl cannot be freed until
- * ALL kobject references to ctrl->cdev are dropped (including those
- * held by still-open file descriptors).  This callback is invoked
- * after cdev_del() + the final kobject_put(), guaranteeing that no
- * thread can access ctrl through the cdev or its kobj anymore.
- */
-static void ctrl_cdev_release(struct kobject *kobj)
-{
-
-    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
-    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
-    kfree(ctrl->user_qid_bitmap);
-    ctrl->user_qid_bitmap = NULL;
-    mutex_destroy(&ctrl->user_qid_lock);
-    kfree(ctrl);
-}
-
-static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
-
 int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
 {
     int err;
     struct device* chrdev = NULL;
+    struct cdev *cdev;
 
     if (ctrl->chrdev != NULL)
     {
@@ -169,28 +151,30 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
         return 0;
     }
 
+    cdev = kmalloc(sizeof(*cdev), GFP_KERNEL);
+    if (!cdev)
+        return -ENOMEM;
+    ctrl->cdev  = cdev;
+
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
 
-    cdev_init(&ctrl->cdev, fops);
-    /*
-     * Override the default kobj_type release so that struct ctrl
-     * (which embeds cdev) survives until every kobject reference is
-     * dropped -- even if userspace still holds an open fd at the time
-     * of SNVM_CHRDEV_REMOVE.
-     */
-    ctrl->cdev.kobj.ktype = &ctrl_ktype;
-    err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
+    cdev_init(ctrl->cdev, fops);
+    err = cdev_add(ctrl->cdev, ctrl->rdev, 1);
     if (err != 0)
     {
         printk(KERN_ERR "Failed to add cdev\n");
+        ctrl->cdev = NULL;
+        kfree(cdev);
         return err;
     }
 
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
     if (IS_ERR(chrdev))
     {
-        cdev_del(&ctrl->cdev);
+        cdev_del(ctrl->cdev);
+        ctrl->cdev = NULL;
+        /* cdev_del may trigger ctrl_cdev_release → kfree(ccdev)+kfree(ctrl) */
         printk(KERN_ERR "Failed to create character device\n");
         return PTR_ERR(chrdev);
     }
@@ -209,28 +193,15 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
-        /*
-         * cdev_del() drops the base kobject reference that cdev_init()
-         * acquired.  If all open file descriptors have already been
-         * closed, the refcount will hit zero inside cdev_del() and
-         * ctrl_cdev_release() will kfree(ctrl) synchronously.
-         *
-         * Save every field we need *after* cdev_del() into local
-         * variables so we never touch a possibly-freed ctrl.
-         */
-        struct class *cls  = ctrl->cls;
-        dev_t         rdev = ctrl->rdev;
-        char          name[64];
-        strscpy(name, ctrl->name, sizeof(name));
-
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
+        device_destroy(ctrl->cls, ctrl->rdev);
+        cdev_del(ctrl->cdev);
         ctrl->chrdev = NULL;
-        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
-        device_destroy(cls, rdev);   /* use saved values */
+        ctrl->cdev   = NULL;
 
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                name, MAJOR(rdev), MINOR(rdev));
+                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
@@ -79,15 +79,13 @@ void ctrl_put(struct ctrl* ctrl)
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
         /*
-         * B3 user-QID bitmap: kfree handles NULL.  By the time
-         * ctrl_put runs, every fd that could allocate from this
-         * pool has been closed (chrdev is being torn down), so
-         * no concurrent access -- no need to take user_qid_lock.
+         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
+         * cdev_del() which unregisters the character device but does
+         * NOT wait for in-flight references to drop.  The actual
+         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
+         * when the last kobject reference to ctrl->cdev.kobj is
+         * released (e.g. after all open file descriptors are closed).
          */
-        kfree(ctrl->user_qid_bitmap);
-        ctrl->user_qid_bitmap = NULL;
-        mutex_destroy(&ctrl->user_qid_lock);
-        kfree(ctrl);
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -137,6 +135,29 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 // EXPORT_SYMBOL_GPL(ctrl_find_by_inode);
 
 
+
+/*
+ * kobject release callback for ctrl->cdev.kobj.
+ *
+ * cdev is embedded in struct ctrl, so ctrl cannot be freed until
+ * ALL kobject references to ctrl->cdev are dropped (including those
+ * held by still-open file descriptors).  This callback is invoked
+ * after cdev_del() + the final kobject_put(), guaranteeing that no
+ * thread can access ctrl through the cdev or its kobj anymore.
+ */
+static void ctrl_cdev_release(struct kobject *kobj)
+{
+
+    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
+    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
+    kfree(ctrl->user_qid_bitmap);
+    ctrl->user_qid_bitmap = NULL;
+    mutex_destroy(&ctrl->user_qid_lock);
+    kfree(ctrl);
+}
+
+static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
+
 int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
 {
     int err;
@@ -150,15 +171,22 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
 
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
-    
+
     cdev_init(&ctrl->cdev, fops);
+    /*
+     * Override the default kobj_type release so that struct ctrl
+     * (which embeds cdev) survives until every kobject reference is
+     * dropped -- even if userspace still holds an open fd at the time
+     * of SNVM_CHRDEV_REMOVE.
+     */
+    ctrl->cdev.kobj.ktype = &ctrl_ktype;
     err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
     if (err != 0)
     {
         printk(KERN_ERR "Failed to add cdev\n");
         return err;
     }
- 
+
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
     if (IS_ERR(chrdev))
     {
@@ -181,14 +209,28 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
+        /*
+         * cdev_del() drops the base kobject reference that cdev_init()
+         * acquired.  If all open file descriptors have already been
+         * closed, the refcount will hit zero inside cdev_del() and
+         * ctrl_cdev_release() will kfree(ctrl) synchronously.
+         *
+         * Save every field we need *after* cdev_del() into local
+         * variables so we never touch a possibly-freed ctrl.
+         */
+        struct class *cls  = ctrl->cls;
+        dev_t         rdev = ctrl->rdev;
+        char          name[64];
+        strscpy(name, ctrl->name, sizeof(name));
+
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
-        device_destroy(ctrl->cls, ctrl->rdev);
-        cdev_del(&ctrl->cdev);
         ctrl->chrdev = NULL;
-        
+        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
+        device_destroy(cls, rdev);   /* use saved values */
+
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
+                name, MAJOR(rdev), MINOR(rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.c
@@ -27,7 +27,6 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     ctrl->number = number;
     ctrl->rdev = 0;
     ctrl->cls = cls;
-    ctrl->cdev   = NULL;
     ctrl->chrdev = NULL;
     ctrl->use_sreg = 0;
     ctrl->ioq_num = 0;
@@ -80,15 +79,13 @@ void ctrl_put(struct ctrl* ctrl)
         list_remove(&ctrl->list);
         ctrl_chrdev_remove(ctrl);
         /*
-         * B3 user-QID bitmap: kfree handles NULL.  By the time
-         * ctrl_put runs, every fd that could allocate from this
-         * pool has been closed (chrdev is being torn down), so
-         * no concurrent access -- no need to take user_qid_lock.
+         * ctrl->cdev is embedded in ctrl.  ctrl_chrdev_remove() calls
+         * cdev_del() which unregisters the character device but does
+         * NOT wait for in-flight references to drop.  The actual
+         * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
+         * when the last kobject reference to ctrl->cdev.kobj is
+         * released (e.g. after all open file descriptors are closed).
          */
-        kfree(ctrl->user_qid_bitmap);
-        ctrl->user_qid_bitmap = NULL;
-        mutex_destroy(&ctrl->user_qid_lock);
-        kfree(ctrl);
     }
 }
 // EXPORT_SYMBOL_GPL(ctrl_put);
@@ -125,7 +122,7 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
     {
         ctrl = container_of(element, struct ctrl, list);
 
-        if (ctrl->cdev && ctrl->cdev == inode->i_cdev)
+        if (&ctrl->cdev == inode->i_cdev)
         {
             return ctrl;
         }
@@ -139,11 +136,33 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
 
 
 
-int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operations* fops)
+/*
+ * kobject release callback for ctrl->cdev.kobj.
+ *
+ * cdev is embedded in struct ctrl, so ctrl cannot be freed until
+ * ALL kobject references to ctrl->cdev are dropped (including those
+ * held by still-open file descriptors).  This callback is invoked
+ * after cdev_del() + the final kobject_put(), guaranteeing that no
+ * thread can access ctrl through the cdev or its kobj anymore.
+ */
+static void ctrl_cdev_release(struct kobject *kobj)
+{
+
+    struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
+    printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
+    kfree(ctrl->user_qid_bitmap);
+    ctrl->user_qid_bitmap = NULL;
+    mutex_destroy(&ctrl->user_qid_lock);
+    kfree(ctrl);
+}
+
+static struct kobj_type ctrl_ktype = {.release = ctrl_cdev_release};
+
+int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first,
+                       const struct file_operations* fops)
 {
     int err;
-    struct device* chrdev = NULL;
-    struct cdev *cdev;
+    struct device* chrdev;
 
     if (ctrl->chrdev != NULL)
     {
@@ -151,32 +170,29 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
         return 0;
     }
 
-    cdev = kmalloc(sizeof(*cdev), GFP_KERNEL);
-    if (!cdev)
-        return -ENOMEM;
-    ctrl->cdev  = cdev;
-
     ctrl->rdev = MKDEV(MAJOR(first), ctrl->number);
     printk("nuo is %d\n", ctrl->rdev);
 
-    cdev_init(ctrl->cdev, fops);
-    err = cdev_add(ctrl->cdev, ctrl->rdev, 1);
-    if (err != 0)
-    {
+    cdev_init(&ctrl->cdev, fops);
+    ctrl->cdev.kobj.ktype = &ctrl_ktype;
+
+    err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
+    if (err != 0) {
         printk(KERN_ERR "Failed to add cdev\n");
-        ctrl->cdev = NULL;
-        kfree(cdev);
+        /* cdev never mapped -> no fd can hold it, refcount == 1.
+         * Take ownership of teardown; caller must NOT ctrl_put(). */
+        list_remove(&ctrl->list);
+        kobject_put(&ctrl->cdev.kobj);   /* -> ctrl_cdev_release -> kfree(ctrl) */
         return err;
     }
 
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
-    if (IS_ERR(chrdev))
-    {
-        cdev_del(ctrl->cdev);
-        ctrl->cdev = NULL;
-        /* cdev_del may trigger ctrl_cdev_release → kfree(ccdev)+kfree(ctrl) */
+    if (IS_ERR(chrdev)) {
         printk(KERN_ERR "Failed to create character device\n");
-        return PTR_ERR(chrdev);
+        err = PTR_ERR(chrdev);
+        list_remove(&ctrl->list);
+        cdev_del(&ctrl->cdev);           /* drops ref -> may kfree(ctrl) */
+        return err;
     }
 
     ctrl->chrdev = chrdev;
@@ -193,15 +209,28 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
 {
     if (ctrl->chrdev != NULL)
     {
+        /*
+         * cdev_del() drops the base kobject reference that cdev_init()
+         * acquired.  If all open file descriptors have already been
+         * closed, the refcount will hit zero inside cdev_del() and
+         * ctrl_cdev_release() will kfree(ctrl) synchronously.
+         *
+         * Save every field we need *after* cdev_del() into local
+         * variables so we never touch a possibly-freed ctrl.
+         */
+        struct class *cls  = ctrl->cls;
+        dev_t         rdev = ctrl->rdev;
+        char          name[64];
+        strscpy(name, ctrl->name, sizeof(name));
+
         // pci_dev_put(ctrl->pdev);
         printk("ctrl_chrdev_remove pci_dev_put\n");
-        device_destroy(ctrl->cls, ctrl->rdev);
-        cdev_del(ctrl->cdev);
         ctrl->chrdev = NULL;
-        ctrl->cdev   = NULL;
+        cdev_del(&ctrl->cdev);       /* may kfree(ctrl) here */
+        device_destroy(cls, rdev);   /* use saved values */
 
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
-                ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
+                name, MAJOR(rdev), MINOR(rdev));
     }
 }
 EXPORT_SYMBOL_GPL(ctrl_chrdev_remove);

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.h
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.h
@@ -58,7 +58,7 @@ struct ctrl
     int                 number;     /* Controller number */
     dev_t               rdev;       /* Character device register */
     struct class*       cls;        /* Character device class */
-    struct cdev         cdev;       /* Character device */
+    struct cdev        *cdev;       /* Character device (separately allocated) */
     struct device*      chrdev;     /* Character device handle */
     struct nvme_dev *dev;
     /*****info about user defined nvme io qp **** */

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.h
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/ctrl.h
@@ -58,7 +58,7 @@ struct ctrl
     int                 number;     /* Controller number */
     dev_t               rdev;       /* Character device register */
     struct class*       cls;        /* Character device class */
-    struct cdev        *cdev;       /* Character device (separately allocated) */
+    struct cdev         cdev;       /* Character device (separately allocated) */
     struct device*      chrdev;     /* Character device handle */
     struct nvme_dev *dev;
     /*****info about user defined nvme io qp **** */

--- a/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/pci.c
+++ b/backends/local/kernel_modules/snvme-5.4.241-1-tlinux4-0017/pci.c
@@ -6983,14 +6983,8 @@ static int snvm_chrdev_create(struct pci_dev *pdev, unsigned int class)
 
 	err = ctrl_chrdev_create(ctrl, dev_first, &snvm_dev_fops);
 	if (err != 0) {
-		/*
-		 * PORTING.md section 7.3.1: same tear-down rule as
-		 * snvm_chrdev_helper(remove) -- ctrl_put() FIRST, then
-		 * ida_simple_remove().  ctrl_put() needs ctrl->number
-		 * (= the minor) to drive device_destroy() / cdev_del()
-		 * for whatever ctrl_chrdev_create() partially built.
-		 */
-		ctrl_put(ctrl);
+		/* ctrl_chrdev_create() already removed + freed ctrl on failure;
+		* do NOT call ctrl_put(ctrl) here. */
 		ida_simple_remove(&snvm_chrdev_minor_ida, minor);
 		return err;
 	}


### PR DESCRIPTION
In the destruct path, kobject_put() attempts to access kobject->name, which points to already freed memory, resulting in an invalid pointer dereference.

```txt
 [  416.562257] (snvm_unbind_driver): disable device for unbind driver 
 [  416.562258] Unbinding device from driver snvme 
 [  416.632836] ctrl_chrdev_remove pci_dev_put 
 [  416.632882] Character device /dev/ssnvme0 removed (501.0) 
 [  416.664902] ------------[ cut here ]------------ 
 [  416.664912] general protection fault, probably for non-canonical address 0x307379736275732d: 0000 [#1] SMP NOPTI 
 [  416.676388] CPU: 125 PID: 10040 Comm: block_storage_g Kdump: loaded Tainted: G           OE     5.15.0-119-generic #129-Ubuntu 
 [  416.689209] Hardware name: JZYH G658V3/T3DMG, BIOS T3DMG00.11 08/31/2023 
 [  416.696762] RIP: 0010:string+0x4d/0xe0 
 [  416.700996] Code: ff 77 3c 45 89 d1 31 f6 49 01 f9 66 45 85 d2 75 19 eb 1e 49 39 f8 76 02 88 07 48 83 c7 01 83 c6 01 48 83 c2 01 4c 39 cf 74 07 <0f> b6 02 84 c0 75 e2 4c 89 c2 e8 04 dd ff ff 5d c3 cc cc cc cc 48 
 [  416.722119] RSP: 0018:ff4c0b8f738a7b28 EFLAGS: 00010086 
 [  416.728015] RAX: 307379736275632d RBX: ff4c0b8f738a7c10 RCX: ffff0a00ffffff04 
 [  416.736055] RDX: 307379736275732d RSI: 0000000000000000 RDI: ff4c0b8f738a7c34 
 [  416.744092] RBP: ff4c0b8f738a7b28 R08: ff4c0b8f738a7c30 R09: ff4c0b90738a7c33 
 [  416.752131] R10: ffffffffffffffff R11: 0000000000000001 R12: ff4c0b8f738a7c30 
 [  416.760170] R13: ff4c0b8f738a7c34 R14: ffffffff86e4355e R15: ffffffff86e4355e 
 [  416.768209] FS:  0000000000000000(0000) GS:ff1617cc7fe40000(0000) knlGS:0000000000000000 
 [  416.777325] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033 
 [  416.783801] CR2: 00007f779fffeab8 CR3: 0000000d05410002 CR4: 0000000000771ee0 
 [  416.791833] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000 
 [  416.799872] DR3: 0000000000000000 DR6: 00000000fffe07f0 DR7: 0000000000000400 
 [  416.807912] PKRU: 55555554 
 [  416.810972] Call Trace: 
 [  416.813738]  <TASK> 
 [  416.816117]  ? show_trace_log_lvl+0x1d6/0x2ea 
 [  416.821038]  ? show_trace_log_lvl+0x1d6/0x2ea 
 [  416.825957]  ? vsnprintf+0x23c/0x550 
 [  416.829995]  ? show_regs.part.0+0x23/0x29 
 [  416.834520]  ? __die_body.cold+0x8/0xd 
 [  416.838750]  ? die_addr+0x3e/0x60 
 [  416.842496]  ? exc_general_protection+0x1c5/0x410 
 [  416.847804]  ? asm_exc_general_protection+0x27/0x30 
 [  416.853308]  ? string+0x4d/0xe0 
 [  416.856857]  vsnprintf+0x23c/0x550 
 [  416.860700]  vprintk_store+0x18e/0x5b0 
 [  416.864924]  ? __wake_up_klogd+0x56/0x70 
 [  416.869356]  ? vprintk_emit+0x128/0x250 
 [  416.873687]  vprintk_emit+0x7d/0x250 
 [  416.877719]  vprintk_default+0x1d/0x30 
 [  416.881950]  vprintk+0x3c/0x70 
 [  416.885406]  __warn_printk+0x6c/0x8d 
 [  416.889444]  kobject_put+0x4a/0x80 
 [  416.893287]  cdev_put+0x19/0x30 
 [  416.896836]  __fput+0x25d/0x280 
 [  416.900384]  ____fput+0xe/0x20 
 [  416.903839]  task_work_run+0x6a/0xb0 
 [  416.907876]  do_exit+0x217/0x3c0 
 [  416.911817]  do_group_exit+0x3b/0xb0 
 [  416.916126]  __x64_sys_exit_group+0x18/0x20 
 [  416.921114]  x64_sys_call+0x1937/0x1fa0
```



Root cause sequence:
1. ctrl_put() -> ctrl_chrdev_remove() -> kfree(ctrl) This frees the ctrl structure along with its embedded cdev.
2. _fput() -> cdev_put() -> kobject_put() This later calls kobject_put() on the already freed cdev's kobject, leading to use-after-free when accessing kobject->name.