### PR TITLE
Fix/daemon

### DIFF
--- a/doc/tutti_daemon.md
+++ b/doc/tutti_daemon.md
@@ -1,0 +1,363 @@
+# tutti_daemon 启动与部署指南
+
+本文说明如何在 CUDA 主机上编译、配置并启动 `tutti_daemon`。示例使用
+`cuda-module` preset、一个 GPU 和一个 NVMe namespace，重点说明以下对象之间
+的关系：
+
+- 物理 NVMe 的 PCI 地址，例如 `0000:31:00.0`；
+- daemon bring-up 后生成的 SNVMe 字符设备和块设备；
+- 挂载真实 ext4 文件系统的 NVMe 目录；
+- 暴露给指定 GPU 的目录和软链接。
+
+文中的 `0000:31:00.0`、`/dev/nvme0n1`、GPU 0 和挂载路径都只是示例。
+必须先在目标主机上确认设备身份，不能直接照抄。
+
+> **数据安全警告**
+>
+> `mkfs.ext4` 会破坏目标 namespace 上的现有文件系统和数据。执行格式化前，
+> 必须同时核对 PCI BDF、型号、序列号、容量、系统盘关系和当前挂载状态。
+> 如果不能确定设备是允许清空的数据盘，请停止，不要执行格式化命令。
+
+## 1. 启动流程概览
+
+加载 snvme kernel module 是启动 `tutti_daemon` 的**前置条件**，不属于 daemon
+自身的启动流程。运行 daemon 前应已经满足：
+
+- `snvme-core.ko` 和 `snvme.ko` 已加载，`/dev/snvm_control` 存在；
+- 目标 NVMe namespace 已准备为 ext4；
+- 本机 YAML 中已经填写正确的 PCI BDF、GPU 和挂载路径。
+
+满足这些前置条件后，`tutti_daemon` 自身的启动顺序如下：
+
+```text
+读取并校验 YAML
+        │
+        ▼
+ServiceState bring-up
+  chrdev_create → kernel IOQ cap → bind → probe
+        │
+        ├── /dev/ssnvme<N>       字符设备，供 libnvm client 使用
+        └── /dev/snvme<N>n<NSID> 块设备，供 ext4 mount 使用
+        │
+        ▼
+MountManager 创建 mount_path 并挂载 ext4
+        │
+        ▼
+确认文件系统已经挂载
+        │
+        ▼
+在真实 NVMe 文件系统内创建 GPU<N> 目录
+并在 GPU view root 下发布软链接
+        │
+        ▼
+启动 reaper 和 gRPC server
+```
+
+## 2. 环境准备
+
+建议从项目根目录执行本文命令：
+
+```bash
+cd /path/to/Tutti
+```
+
+需要以下基础环境：
+
+- CMake 3.21 或更新版本；
+- 与目标 GPU 驱动匹配的 CUDA toolkit；
+- 当前内核对应的 headers/devel 包；
+- `lspci`、`lsblk`、`findmnt`、`blkid`；
+- 可选的 `nvme-cli`，用于查看 NVMe 型号、序列号和 namespace；
+- `e2fsprogs`，仅在需要执行 `mkfs.ext4` 时使用。
+
+依赖和 preset 的完整准备方式见 [build_and_test.md](build_and_test.md)。
+
+## 3. 查找目标 NVMe 及其 PCI 地址
+
+使用项目提供的 PCI 拓扑脚本发现 GPU、NVMe 和 PCI BDF：
+
+```bash
+sudo bash scripts/pci_topology_check.sh
+```
+
+脚本会直接打印：
+
+- GPU index 和 GPU BDF；
+- 每块 NVMe 的完整 BDF；
+- NVMe 当前由标准 `nvme` 驱动管理时对应的 `/dev/nvme...` namespace；
+- 每个 GPU/NVMe 组合的拓扑距离。
+
+示例：
+
+```text
+Found GPU 0: 0000:4b:00.0
+Found NVMe: 0000:31:00.0 -> N/A
+
+NVMe \ GPU                      GPU0
+N/A (31:00.0)                   1
+```
+
+距离含义为：`0` 表示相同 PCIe switch/root complex，`1` 表示相同 NUMA node，
+`2` 表示跨 NUMA。通常优先选择距离较小的 NVMe，并据此填写 `allowed_gpus`。
+
+结果同时保存在：
+
+```text
+/mnt/sys_GPU_NVMe_topology.json
+```
+
+JSON 中的 `nvme_bdf` 用于填写 `nvmes[].pci_addr`，`gpu_index` 用于填写
+`gpus[].id` 和 `allowed_gpus`。如果 `nvme_device` 为 `N/A`，表示该设备当前没有
+绑定到标准 `nvme` 驱动；BDF 和拓扑结果仍然有效，下一章使用项目 bind 脚本后
+即可获得 `/dev/nvme...` 设备。
+
+配置文件中的 PCI 地址必须使用带 domain 的完整形式 `DDDD:BB:DD.F`，例如
+`0000:31:00.0`。
+
+## 4. 检查或创建 ext4 文件系统
+
+检查或重建文件系统前，应先停止 `tutti_daemon` 并确认目标盘没有挂载。使用
+上一章得到的 PCI BDF，将目标设备绑定到标准 Linux `nvme` 驱动：
+
+```bash
+sudo bash scripts/bind_nvme_device.sh 0000:31:00.0
+```
+
+脚本会校验 PCI 设备类型、切换驱动并输出注册后的 NVMe controller。然后找出
+它对应的 namespace，例如 `/dev/nvme0n1`，检查文件系统类型：
+
+```bash
+lsblk -f
+sudo blkid /dev/nvme0n1
+```
+
+如果 `FSTYPE`/`TYPE` 为 `ext4`，通过一次临时 mount 验证：
+
+```bash
+sudo mkdir -p /mnt/tutti-ext4-check
+sudo mount -t ext4 /dev/nvme0n1 /mnt/tutti-ext4-check
+findmnt /mnt/tutti-ext4-check
+sudo umount /mnt/tutti-ext4-check
+```
+
+mount 成功且 `findmnt` 显示 `ext4`，说明该 namespace 可以交给 daemon 使用。
+当前 daemon 挂载整个 namespace，因此文件系统应建立在 `/dev/nvme0n1`，而不是
+`/dev/nvme0n1p1` 分区。
+
+### 可选：创建新的 ext4 文件系统
+
+如果检查结果不是 ext4，并且确认该 namespace 允许被清空，可以使用 `mkfs`
+重建 ext4 文件系统：
+
+```bash
+sudo mkfs.ext4 -F -L tutti-nvme0 /dev/nvme0n1
+```
+
+> **警告：**`mkfs.ext4` 会重建文件系统并清除原有数据。必须确认设备名来自
+> `bind_nvme_device.sh` 所绑定的目标 BDF，并确认它不是系统盘或业务盘。
+
+完成后重复上一节的 `blkid` 和临时 mount 测试；卸载测试目录后再启动 daemon。
+
+## 5. cuda-module 构建和 module 前置条件
+
+使用 `cuda-module` preset 构建 snvme module 和生产 daemon：
+
+```bash
+cmake --preset cuda-module
+cmake --build --preset cuda-module \
+  --target modules tutti_daemon --parallel 8
+```
+
+在启动 daemon 前安装 module：
+
+```bash
+cmake --build --preset cuda-module --target insmod
+```
+
+`cuda-module` 的环境准备、内核 baseline、P2P backend、module 产物和 reload
+流程见 [build_and_test.md](build_and_test.md)。本章只要求 daemon 启动前已经
+完成 `insmod`，并存在 `/dev/snvm_control`。
+
+## 6. 创建本机 YAML 配置
+
+本机配置应放在 `config/local/` 下。该目录中的 `*.yaml` 和 `*.yml` 已被
+Git 忽略，适合保存不同机器的 PCI、GPU 和挂载路径配置。
+
+可以从仓库模板复制：
+
+```bash
+cp config/local_nvme_config.yaml config/local/tutti_daemon.yaml
+```
+
+然后删除不属于本机的设备项并修改配置。单 GPU、单 NVMe 示例：
+
+```yaml
+grpc:
+  endpoint: "127.0.0.1:50051"
+
+gpus:
+  - id: 0
+    mount_path: "/mnt/gpu0"
+
+nvmes:
+  - pci_addr: "0000:31:00.0"
+    mount_path: "/mnt/nvme0"
+    namespace_id: 1
+    kernel_ioq_cap: 32
+    allowed_gpus: [0]
+    auto_mount: true
+
+queue_pool:
+  default_per_client: 32
+  max_per_client: 32
+
+lease:
+  heartbeat_interval_sec: 10
+  timeout_sec: 30
+
+unmount_retry:
+  interval_ms: 1000
+  max: 30
+```
+
+字段说明：
+
+| 字段 | 含义 |
+| --- | --- |
+| `grpc.endpoint` | daemon 的 gRPC 监听地址 |
+| `gpus[].id` | CUDA device index |
+| `gpus[].mount_path` | 该 GPU 的视图根目录，不是真实磁盘挂载点 |
+| `nvmes[].pci_addr` | 目标 NVMe 的完整 PCI BDF，也是最重要的设备身份 |
+| `nvmes[].mount_path` | 真实 NVMe ext4 文件系统的挂载点 |
+| `namespace_id` | NVMe namespace ID，通常为 1 |
+| `kernel_ioq_cap` | bind 前设置的内核 IO queue cap；0 表示使用内核默认值 |
+| `allowed_gpus` | 可以连接并获得该 NVMe 视图的 GPU ID；省略或为空表示所有已配置 GPU |
+| `auto_mount` | `true` 表示 daemon 挂载并在退出时卸载；通常应保持为 `true` |
+| `unmount_retry` | 退出时遇到 `EBUSY` 的重试间隔和次数 |
+
+`nvmes` 数组的顺序决定 daemon 的 `device_id`。例如第一个条目为
+`device_id=0`；在 `namespace_id: 1` 时，daemon 会尝试挂载
+`/dev/snvme0n1`。第二个条目对应 `device_id=1` 和 `/dev/snvme1n1`。
+
+## 7. 使用指定 YAML 启动 daemon
+
+建议启用详细日志，以便观察 bring-up、mount 和 shutdown：
+
+```bash
+sudo env TUTTI_VERBOSE=1 \
+  ./build/cuda-module/tutti/device_manager/nvme/nvmeservice/examples/tutti_daemon \
+  --config config/local/tutti_daemon.yaml
+```
+
+启动过程需要 root 权限，因为 daemon 要执行 controller bind、创建字符设备、
+挂载文件系统和创建系统目录。
+
+### 7.1 启动成功标志
+
+详细日志中的关键成功信息类似：
+
+```text
+nvmeservice: device=0 pci=0000:31:00.0 snvme=/dev/ssnvme0 ns=1 ...
+mount_manager: mounted /dev/snvme0n1 at /mnt/nvme0 (owned)
+tutti_daemon listening on 127.0.0.1:50051 (port 50051)
+Owned devices:
+  device_id=0 pci=0000:31:00.0 snvme=/dev/ssnvme0 ns=1 ...
+```
+
+`tutti_daemon listening` 只说明 gRPC 已启动。完整成功还必须确认 mount 和 GPU view，
+因为 mount 失败时 daemon 会打印 warning 并继续启动 gRPC。启动日志中不应出现：
+
+```text
+warning: auto-mount ... failed
+warning: ... is not mounted; GPU views ... will not be published
+```
+
+在另一个终端执行：
+
+```bash
+ls -l /dev/snvm_control /dev/ssnvme0 /dev/snvme0n1
+findmnt -no SOURCE,FSTYPE,TARGET /mnt/nvme0
+test -d /mnt/nvme0/GPU0
+readlink -f /mnt/gpu0/ssnvme0
+ss -ltn | grep ':50051'
+```
+
+单盘示例的期望关系是：
+
+```text
+/dev/snvme0n1 ext4 /mnt/nvme0
+/mnt/gpu0/ssnvme0 -> /mnt/nvme0/GPU0
+```
+
+也可以直接证明某个路径位于哪个文件系统：
+
+```bash
+findmnt -T /mnt/nvme0/GPU0
+findmnt -T /mnt/gpu0/ssnvme0
+```
+
+## 8. 启动后生成的设备和目录
+
+假设 YAML 中第一个 NVMe 允许 GPU 0 使用，启动后对象含义如下：
+
+| 对象 | 类型 | 是否承载真实 NVMe 数据 | 作用 |
+| --- | --- | ---: | --- |
+| `/dev/snvm_control` | module control 字符设备 | 否 | daemon 执行 create/bind 等 owner 操作 |
+| `/dev/ssnvme0` | per-controller 字符设备 | 否 | client/libnvm attach、队列和映射操作 |
+| `/dev/snvme0n1` | namespace 块设备 | 是 | ext4 的 mount source |
+| `/mnt/nvme0` | ext4 mount root | 是 | `nvmes[0].mount_path`，真实磁盘根目录 |
+| `/mnt/nvme0/GPU0` | ext4 内的普通目录 | 是 | GPU 0 对应的真实数据目录 |
+| `/mnt/gpu0` | GPU view root | 否 | `gpus[id=0].mount_path`，用于组织软链接 |
+| `/mnt/gpu0/ssnvme0` | 软链接 | 间接指向真实数据 | 指向 `/mnt/nvme0/GPU0` |
+
+目录关系为：
+
+```text
+PCI 0000:31:00.0
+  └─ YAML nvmes[0] / daemon device_id=0
+      ├─ /dev/ssnvme0                 client 字符设备
+      └─ /dev/snvme0n1                namespace 块设备
+          └─ mount ext4 at /mnt/nvme0 真实 NVMe 文件系统
+              └─ GPU0                 真实 NVMe 目录
+                  ▲
+                  └── /mnt/gpu0/ssnvme0 软链接
+```
+
+如果 `allowed_gpus: [0, 2]`，daemon 会在同一个真实 NVMe 文件系统内创建
+`GPU0` 和 `GPU2`，并分别从 GPU 0、GPU 2 的 view root 发布软链接。
+
+daemon 只创建 `GPU<N>` 目录，不会自动创建 `resolver_test` 等测试目录。
+应用写入 `/mnt/gpu0/ssnvme0/...` 时，软链接最终解析到
+`/mnt/nvme0/GPU0/...`，数据实际位于该 NVMe 的 ext4 文件系统上。
+
+## 9. 优雅停止
+
+在前台按一次 `Ctrl-C`，或从另一个终端发送一次 `SIGTERM`：
+
+```bash
+sudo kill -TERM <tutti_daemon_pid>
+```
+
+正常关闭顺序为：
+
+```text
+停止 gRPC
+  → 停止 reaper
+  → 删除 GPU view 软链接
+  → 删除空的 GPU<N> 目录
+  → 卸载 daemon 自己挂载的 ext4
+  → 释放 controller，移除 per-controller 设备节点
+```
+
+如果 `GPU<N>` 内仍有业务文件，daemon 只会尝试 `rmdir`，不会递归删除数据；
+目录会保留在 NVMe 文件系统内。退出后可检查：
+
+```bash
+findmnt /mnt/nvme0
+test ! -L /mnt/gpu0/ssnvme0
+ls -l /dev/ssnvme0 /dev/snvme0n1
+```
+
+当卸载因 holder 返回 `EBUSY` 时，daemon 会报告相关 PID、fd、maps 或 cwd，并按
+`unmount_retry` 重试。第二次发送信号会强制结束重试并留下挂载；除非处于明确的
+应急恢复流程，否则不要发送第二次信号，更不要使用 `kill -9`。

--- a/tests/mount_manager_contract/CMakeLists.txt
+++ b/tests/mount_manager_contract/CMakeLists.txt
@@ -6,7 +6,8 @@
 #   1. config parsing (auto_mount field, unmount_retry block)
 #   2. /proc parsing helpers (scan_holders against the test process itself)
 #   3. is_mounted() against /proc/self/mountinfo
-#   4. mount_one/unmount_all lifecycle using a loopback tmpfs (no real NVMe)
+#   4. recursive mount-point preparation
+#   5. mount_one/unmount_all lifecycle using a loopback tmpfs (no real NVMe)
 
 find_package(Threads REQUIRED)
 find_package(yaml-cpp REQUIRED)

--- a/tests/mount_manager_contract/mount_manager_contract_test.cpp
+++ b/tests/mount_manager_contract/mount_manager_contract_test.cpp
@@ -6,9 +6,10 @@
 //   1. config parsing (auto_mount field, unmount_retry block, defaults)
 //   2. is_mounted() against /proc/self/mountinfo
 //   3. scan_holders() finds the test process itself when it holds an fd
-//   4. mount_one() + unmount_all() lifecycle using a loopback tmpfs
-//   5. force_exit_requested() short-circuits the retry loop
-//   6. path_is_prefix() edge cases (not directly exposed, but tested
+//   4. mount_one() recursively prepares a configured mount point
+//   5. mount_one() + unmount_all() lifecycle using a loopback tmpfs
+//   6. force_exit_requested() short-circuits the retry loop
+//   7. path_is_prefix() edge cases (not directly exposed, but tested
 //      indirectly via scan_holders with paths that share prefixes)
 
 #include "mount_manager.h"
@@ -183,10 +184,37 @@ static void test_scan_holders_self() {
 }
 
 // =====================================================================
-// Test 5: mount_one + unmount_all lifecycle with tmpfs
+// Test 5: mount_one owns recursive mount-point preparation
+// =====================================================================
+static void test_recursive_mount_point_creation() {
+    std::fprintf(stderr, "=== Test 5: recursive mount-point creation ===\n");
+
+    char base_template[] = "/tmp/tutti_mount_pathXXXXXX";
+    char* base_dir = ::mkdtemp(base_template);
+    CHECK(base_dir != nullptr, "mkdtemp for recursive mount point");
+    if (!base_dir) return;
+
+    const fs::path mount_path = fs::path(base_dir) / "nested" / "nvme0";
+    nvmeservice::UnmountRetryConfig rc;
+    nvmeservice::MountManager mgr(rc);
+
+    // The device intentionally does not exist.  mount(2) must fail, but the
+    // complete configured mount-point hierarchy must already have been made.
+    auto mr = mgr.mount_one("/dev/tutti_missing_block_device", mount_path.string());
+    CHECK(!mr.error.empty(), "missing block device fails mount");
+    CHECK(fs::is_directory(mount_path), "mount_one creates nested mount point");
+    CHECK(!mr.mounted_by_daemon, "failed mount is not daemon-owned");
+
+    std::error_code ec;
+    fs::remove_all(base_dir, ec);
+    CHECK(!ec, "remove recursive mount-point fixture");
+}
+
+// =====================================================================
+// Test 6: mount_one + unmount_all lifecycle with tmpfs
 // =====================================================================
 static void test_mount_lifecycle() {
-    std::fprintf(stderr, "=== Test 5: mount lifecycle (tmpfs) ===\n");
+    std::fprintf(stderr, "=== Test 6: mount lifecycle (tmpfs) ===\n");
 
     // Create a directory to use as mount point.
     char mnt_template[] = "/tmp/tutti_mntXXXXXX";
@@ -235,10 +263,10 @@ static void test_mount_lifecycle() {
 }
 
 // =====================================================================
-// Test 6: force_exit short-circuits retry loop
+// Test 7: force_exit short-circuits retry loop
 // =====================================================================
 static void test_force_exit() {
-    std::fprintf(stderr, "=== Test 6: force_exit ===\n");
+    std::fprintf(stderr, "=== Test 7: force_exit ===\n");
 
     nvmeservice::UnmountRetryConfig rc;
     rc.interval_ms = 10000;  // long sleep so force_exit triggers during wait
@@ -254,10 +282,10 @@ static void test_force_exit() {
 }
 
 // =====================================================================
-// Test 7: scan_holders with cwd — child process cd's into a mount
+// Test 8: scan_holders with cwd — child process cd's into a mount
 // =====================================================================
 static void test_scan_holders_cwd() {
-    std::fprintf(stderr, "=== Test 7: scan_holders (cwd) ===\n");
+    std::fprintf(stderr, "=== Test 8: scan_holders (cwd) ===\n");
 
     // Fork a child that cd's into /tmp and sleeps.
     pid_t pid = ::fork();
@@ -291,6 +319,7 @@ int main() {
     test_config_defaults();
     test_is_mounted();
     test_scan_holders_self();
+    test_recursive_mount_point_creation();
     test_mount_lifecycle();
     test_force_exit();
     test_scan_holders_cwd();

--- a/tutti/device_manager/nvme/nvmeservice/NVMeService.md
+++ b/tutti/device_manager/nvme/nvmeservice/NVMeService.md
@@ -268,7 +268,8 @@ nvmeservice_client [--endpoint host:port] [--list-only]
 Daemon boot
   └─ for each nvmes[]:
        nvm_controller_init_b3()          → /dev/ssnvmeN, ctrl held forever
-       install /mnt/gpu<G>/ssnvmeN  →  /mnt/nvmeM/GPU<G>
+       mount /dev/snvmeMn<ns>            → /mnt/nvmeM
+       publish /mnt/gpu<G>/ssnvmeN       → /mnt/nvmeM/GPU<G>
 
 Client Connect
   Server::Connect:

--- a/tutti/device_manager/nvme/nvmeservice/examples/nvmeservice_daemon.cpp
+++ b/tutti/device_manager/nvme/nvmeservice/examples/nvmeservice_daemon.cpp
@@ -3,12 +3,13 @@
  *
  * Reads sys_config.yaml, brings up every NVMe controller described
  * there as the *owner* (libnvm B3: chrdev_create + cap + bind + probe),
- * installs per-GPU view symlinks, starts the gRPC server, and runs
- * until SIGINT/SIGTERM.  No quota ledger is maintained -- the kernel
- * owns user QID accounting.
+ * publishes per-GPU view symlinks for filesystems already mounted by
+ * the operator, starts the gRPC server, and runs until SIGINT/SIGTERM.
+ * No quota ledger is maintained -- the kernel owns user QID accounting.
  */
 
 #include "nvmeservice_config.h"
+#include "mount_manager.h"
 #include "nvmeservice_server.h"
 #include "nvmeservice_state.h"
 
@@ -102,6 +103,21 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        // This example does not own the mount lifecycle.  Publish only views
+        // backed by a mount the operator prepared; never create GPU<n> on the
+        // host filesystem as a substitute for a missing mount.
+        for (size_t i = 0; i < cfg.nvmes.size(); ++i) {
+            const auto& nvme = cfg.nvmes[i];
+            if (!nvmeservice::MountManager::is_mounted(nvme.mount_path)) {
+                std::fprintf(stderr,
+                    "warning: %s is not mounted; GPU views for device_id=%zu "
+                    "will not be published\n",
+                    nvme.mount_path.c_str(), i);
+                continue;
+            }
+            state->publish_gpu_views(static_cast<int32_t>(i));
+        }
+
         state->start_reaper();
 
         nvmeservice::NvmeServiceImpl svc(state);
@@ -167,6 +183,7 @@ int main(int argc, char** argv) {
         server->Wait();
 
         state->stop_reaper();
+        state->unpublish_gpu_views();
         std::cout << "Daemon exited cleanly.\n";
     }
 

--- a/tutti/device_manager/nvme/nvmeservice/examples/tutti_daemon.cpp
+++ b/tutti/device_manager/nvme/nvmeservice/examples/tutti_daemon.cpp
@@ -4,7 +4,8 @@
  * The owner half of the SERVICE_CLIENT data plane.  This process is
  * the sole owner of every NVMe controller named in sys_config.yaml:
  * it does the libnvm B3 bring-up (chrdev_create + cap + bind + probe),
- * installs per-GPU view symlinks, and serves gRPC so that Coordinator
+ * mounts each block device, publishes per-GPU view symlinks, and serves
+ * gRPC so that Coordinator
  * instances running in SERVICE_CLIENT mode (see
  * coordinator/include/coordinator_config.h) can attach as libnvm
  * clients and build their own user queue groups.
@@ -195,6 +196,27 @@ int main(int argc, char** argv) {
         }
     }
 
+    // Publish filesystem views only after the backing mount is visible.
+    // ServiceState bring-up creates the block device, but deliberately does
+    // not mkdir <mount>/GPU<n>: doing so before mount(2) would create the
+    // directory on the host filesystem and the mount would hide it.
+    for (size_t i = 0; i < cfg.nvmes.size(); ++i) {
+        const auto& nvme = cfg.nvmes[i];
+        if (!nvmeservice::MountManager::is_mounted(nvme.mount_path)) {
+            std::fprintf(stderr,
+                         "warning: %s is not mounted; GPU views for "
+                         "device_id=%zu will not be published\n",
+                         nvme.mount_path.c_str(), i);
+            continue;
+        }
+        if (!state->publish_gpu_views(static_cast<int32_t>(i))) {
+            std::fprintf(stderr,
+                         "warning: one or more GPU views for device_id=%zu "
+                         "could not be published\n",
+                         i);
+        }
+    }
+
     state->start_reaper();
 
     nvmeservice::NvmeServiceImpl svc(state);
@@ -211,6 +233,8 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "Failed to start gRPC server on %s\n",
                      cfg.grpc.endpoint.c_str());
         state->stop_reaper();
+        state->unpublish_gpu_views();
+        mount_mgr.unmount_all();
         return 1;
     }
 
@@ -248,6 +272,12 @@ int main(int argc, char** argv) {
     server->Shutdown();
     server->Wait();
     state->stop_reaper();
+
+    // Symlinks and empty GPU<n> directories belong to the mounted
+    // filesystem, so remove them before mount_manager hides that filesystem
+    // again.  The destructor repeats this defensively; the operation is
+    // idempotent.
+    state->unpublish_gpu_views();
 
     // Round 17 S1: auto-unmount with EBUSY diagnostics + retry.
     if (g_force_exit.load(std::memory_order_relaxed)) {

--- a/tutti/device_manager/nvme/nvmeservice/src/mount_manager.cpp
+++ b/tutti/device_manager/nvme/nvmeservice/src/mount_manager.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <dirent.h>
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <mntent.h>
 #include <sstream>
@@ -100,20 +101,25 @@ MountResult MountManager::mount_one(const std::string& block_device,
     MountResult res;
     res.block_device = block_device;
 
-    // 1. Create mount point if it doesn't exist.
+    // 1. Create the mount point, including configured parent directories.
+    // ServiceState no longer creates <mount_path>/GPU<n> before mount(2), so
+    // mount-point preparation belongs entirely to MountManager.
+    std::error_code ec;
+    std::filesystem::create_directories(mount_path, ec);
+    if (ec) {
+        res.error = "mkdir " + mount_path + " failed: " + ec.message();
+        return res;
+    }
+
     struct stat st;
     if (::stat(mount_path.c_str(), &st) != 0) {
-        if (errno == ENOENT) {
-            if (::mkdir(mount_path.c_str(), 0755) != 0 && errno != EEXIST) {
-                res.error = "mkdir " + mount_path + " failed: " +
-                            std::strerror(errno);
-                return res;
-            }
-        } else {
-            res.error = "stat " + mount_path + " failed: " +
-                        std::strerror(errno);
-            return res;
-        }
+        res.error = "stat " + mount_path + " failed: " +
+                    std::strerror(errno);
+        return res;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        res.error = mount_path + " is not a directory";
+        return res;
     }
 
     // 2. Check if already mounted (by a previous operator or daemon).

--- a/tutti/device_manager/nvme/nvmeservice/src/mount_manager.cpp
+++ b/tutti/device_manager/nvme/nvmeservice/src/mount_manager.cpp
@@ -125,7 +125,7 @@ MountResult MountManager::mount_one(const std::string& block_device,
     // 2. Check if already mounted (by a previous operator or daemon).
     if (is_mounted(mount_path)) {
         res.already_mounted = true;
-        TUTTI_INFO("mount_manager: %s already mounted at %s (not taking ownership)",
+        TUTTI_INFO("mount_manager: %s already mounted at %s (not taking ownership)\n",
                    block_device.c_str(), mount_path.c_str());
         return res;
     }
@@ -135,14 +135,14 @@ MountResult MountManager::mount_one(const std::string& block_device,
     if (rc != 0) {
         res.error = "mount(" + block_device + ", " + mount_path +
                     ", ext4) failed: " + std::strerror(errno);
-        TUTTI_INFO("mount_manager: %s (continuing without mount)", res.error.c_str());
+        TUTTI_INFO("mount_manager: %s (continuing without mount)\n", res.error.c_str());
         return res;
     }
 
     // 4. Record ownership.
     res.mounted_by_daemon = true;
     owned_mounts_.push_back({block_device, mount_path});
-    TUTTI_INFO("mount_manager: mounted %s at %s (owned)",
+    TUTTI_INFO("mount_manager: mounted %s at %s (owned)\n",
                block_device.c_str(), mount_path.c_str());
     return res;
 }
@@ -278,14 +278,14 @@ int MountManager::unmount_all() {
 
             int err = try_umount_(m.mount_path);
             if (err == 0) {
-                TUTTI_INFO("mount_manager: unmounted %s", m.mount_path.c_str());
+                TUTTI_INFO("mount_manager: unmounted %s\n", m.mount_path.c_str());
                 unmounted = true;
                 break;
             }
 
             if (err == EINVAL) {
                 // Not a mount point anymore (already gone or never was).
-                TUTTI_INFO("mount_manager: %s not a mount point (EINVAL), skipping",
+                TUTTI_INFO("mount_manager: %s not a mount point (EINVAL), skipping\n",
                            m.mount_path.c_str());
                 unmounted = true;
                 break;

--- a/tutti/device_manager/nvme/nvmeservice/src/nvmeservice.proto
+++ b/tutti/device_manager/nvme/nvmeservice/src/nvmeservice.proto
@@ -132,7 +132,8 @@ message ConnectResponse {
     // --- GPU-view filesystem path for this allocation ---
     // Daemon-installed symlink under the consuming GPU's mount_path,
     // e.g. "/mnt/gpu0/ssnvme0", pointing at "/mnt/nvme0/GPU0".
-    // Empty string if symlink installation failed at init time.
+    // Empty string if the backing filesystem was not mounted or view
+    // publication failed before the server started.
     string  mount_path      = 32;
 
     // --- Error info; empty on success ---

--- a/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_client.h
+++ b/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_client.h
@@ -42,7 +42,8 @@
 namespace nvmeservice {
 
 // One ACL row from DeviceInfo.allowed_gpus[].  mount_path is the
-// GPU-view symlink the daemon installed; empty == install failed.
+// GPU-view symlink the daemon published; empty == mount not ready or
+// publication failed.
 struct ClientAllowedGpu {
     int32_t     cuda_device = -1;
     std::string mount_path;
@@ -105,8 +106,9 @@ public:
         // skips GET_DEV_INFO), so it arrives via RPC.
         uint64_t    max_data_size = 0;
 
-        // GPU-view symlink path the daemon installed for
-        // (cuda_device, NVMe).  Empty if symlink install failed.
+        // GPU-view symlink path the daemon published for
+        // (cuda_device, NVMe).  Empty if the mount was not ready or
+        // publication failed.
         std::string mount_path;
 
         // Lease parameters (informational; heartbeat thread uses these).

--- a/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_state.cu
+++ b/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_state.cu
@@ -97,8 +97,8 @@ ServiceState::ServiceState(const ServiceConfig& cfg) : cfg_(cfg) {
 
 ServiceState::~ServiceState() {
     stop_reaper();
+    unpublish_gpu_views();
     for (auto& dev : devices_) {
-        remove_gpu_symlinks(dev);
         if (dev.ctrl != nullptr) {
             // Owner-side teardown: nvm_ctrl_free cascades through
             // SNVM_DEVICE_UNBIND + SNVM_CHRDEV_REMOVE.
@@ -175,8 +175,6 @@ void ServiceState::init_device(const NvmeEntry& nvme, int32_t device_id) {
         for (int gid : nvme.allowed_gpus) dev.allowed_gpus.insert(gid);
     }
 
-    install_gpu_symlinks(dev);
-
     // Bring-up banner — info level, gated by TUTTI_VERBOSE.
     TUTTI_INFO(
         "nvmeservice: device=%d pci=%s snvme=%s ns=%u qdepth=%u "
@@ -200,8 +198,27 @@ void ServiceState::init_device(const NvmeEntry& nvme, int32_t device_id) {
 // GPU-view symlink lifecycle
 // ---------------------------------------------------------------------------
 
-void ServiceState::install_gpu_symlinks(DeviceState& dev) {
+bool ServiceState::publish_gpu_views(int32_t device_id) {
+    std::lock_guard<std::mutex> lock(state_mtx_);
+    if (device_id < 0 || device_id >= static_cast<int32_t>(devices_.size())) {
+        std::fprintf(stderr,
+            "warning: cannot publish GPU views for invalid device_id=%d\n",
+            device_id);
+        return false;
+    }
+    return install_gpu_symlinks(devices_[device_id]);
+}
+
+void ServiceState::unpublish_gpu_views() {
+    std::lock_guard<std::mutex> lock(state_mtx_);
+    for (auto& dev : devices_) {
+        remove_gpu_symlinks(dev);
+    }
+}
+
+bool ServiceState::install_gpu_symlinks(DeviceState& dev) {
     namespace fs = std::filesystem;
+    bool all_installed = true;
 
     // Symlink name under each consuming GPU's mount_path is the
     // basename of the snvme device node.
@@ -218,7 +235,13 @@ void ServiceState::install_gpu_symlinks(DeviceState& dev) {
 
     for (int gpu_id : dev.allowed_gpus) {
         const std::string* gpu_mount = gpu_mount_for(gpu_id);
-        if (gpu_mount == nullptr || gpu_mount->empty()) continue;
+        if (gpu_mount == nullptr || gpu_mount->empty()) {
+            std::fprintf(stderr,
+                "warning: no GPU view root configured for gpu_id=%d\n",
+                gpu_id);
+            all_installed = false;
+            continue;
+        }
 
         const fs::path nvme_subdir = fs::path(dev.mount_path) /
             ("GPU" + std::to_string(gpu_id));
@@ -230,11 +253,19 @@ void ServiceState::install_gpu_symlinks(DeviceState& dev) {
             std::fprintf(stderr,
                 "warning: mkdir %s failed: %s\n",
                 nvme_subdir.c_str(), ec.message().c_str());
+            all_installed = false;
             continue;
         }
         dev.created_nvme_subdirs.push_back(nvme_subdir.string());
 
         fs::create_directories(*gpu_mount, ec);
+        if (ec) {
+            std::fprintf(stderr,
+                "warning: mkdir %s failed: %s\n",
+                gpu_mount->c_str(), ec.message().c_str());
+            all_installed = false;
+            continue;
+        }
 
         std::error_code link_ec;
         const fs::file_status st = fs::symlink_status(link_path, link_ec);
@@ -250,6 +281,7 @@ void ServiceState::install_gpu_symlinks(DeviceState& dev) {
             std::fprintf(stderr,
                 "warning: %s exists and is not a symlink; refusing to overwrite\n",
                 link_path.c_str());
+            all_installed = false;
             continue;
         }
 
@@ -258,11 +290,13 @@ void ServiceState::install_gpu_symlinks(DeviceState& dev) {
             std::fprintf(stderr,
                 "warning: symlink %s -> %s failed: %s\n",
                 link_path.c_str(), nvme_subdir.c_str(), link_ec.message().c_str());
+            all_installed = false;
             continue;
         }
         dev.created_symlinks.push_back(link_path.string());
         dev.gpu_view_paths[gpu_id] = link_path.string();
     }
+    return all_installed;
 }
 
 void ServiceState::remove_gpu_symlinks(DeviceState& dev) {

--- a/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_state.h
+++ b/tutti/device_manager/nvme/nvmeservice/src/nvmeservice_state.h
@@ -19,7 +19,8 @@
  *     freed at daemon shutdown).
  *   * The kernel-reported metadata (max_user_qid, max_queues_per_group,
  *     queue_depth, dstrd, bar0_size) -- read once from NVM_GET_DEV_INFO.
- *   * Per-GPU mount-path symlinks installed at startup.
+ *   * Per-GPU mount-path symlinks published after the backing filesystems
+ *     are mounted.
  *   * Per-allocation lease (PID + starttime + last_heartbeat) for the
  *     reaper to clean up dead clients' bookkeeping.  No quota refund
  *     is needed -- the kernel's snvm_dev_release fd-cascade reclaims
@@ -56,7 +57,7 @@ namespace nvmeservice {
 
 // One row per allowed GPU on a device, telling clients where the
 // per-GPU view directory lives.  Empty mount_path means symlink
-// install failed at daemon startup.
+// publication failed after the backing filesystem was mounted.
 struct AllowedGpuView {
     int32_t     cuda_device = -1;
     std::string mount_path;
@@ -147,11 +148,12 @@ struct DeviceState {
     std::unordered_set<int>  allowed_gpus;
 
     // cuda_device -> per-GPU symlink path (e.g. "/mnt/gpu0/ssnvme0").
-    // Populated during install_gpu_symlinks; entries with empty
-    // string mean install failed for that GPU.
+    // Populated during publish_gpu_views(); a missing entry means
+    // publication failed or was skipped because the mount was not ready.
     std::unordered_map<int, std::string> gpu_view_paths;
 
-    // Symlinks created at init_device time, removed in dtor.
+    // Paths managed by publish_gpu_views(), removed by
+    // unpublish_gpu_views() (and defensively by the destructor).
     std::vector<std::string> created_symlinks;
     std::vector<std::string> created_nvme_subdirs;
 };
@@ -163,10 +165,11 @@ struct DeviceState {
 class ServiceState {
 public:
     /**
-     * Initialise all devices from config: bring up libnvm controller
-     * (owner role: chrdev_create + cap + bind + probe), install
-     * GPU-view symlinks for every allowed GPU.  Throws
-     * std::runtime_error on failure.
+     * Initialise all devices from config: bring up each libnvm controller
+     * (owner role: chrdev_create + cap + bind + probe).  GPU filesystem
+     * views are deliberately NOT created here: the block devices only exist
+     * after bring-up, so the daemon must mount them first and then call
+     * publish_gpu_views().  Throws std::runtime_error on bring-up failure.
      */
     explicit ServiceState(const ServiceConfig& cfg);
     ~ServiceState();
@@ -176,6 +179,24 @@ public:
 
     void start_reaper();
     void stop_reaper();
+
+    /**
+     * Publish the per-GPU filesystem views for one ready device.
+     *
+     * The caller must first verify that DeviceState::mount_path is a mounted
+     * filesystem.  Keeping that mount decision in the daemon prevents this
+     * class from creating GPU<n> directories on the host filesystem and then
+     * having a later mount hide them.
+     *
+     * Returns false for an invalid device id or if any directory/symlink
+     * could not be installed.  Successful views remain available when a
+     * different GPU view fails.
+     */
+    bool publish_gpu_views(int32_t device_id);
+
+    // Remove published GPU-view symlinks and empty subdirectories.
+    // Idempotent; the production daemon calls this before unmounting.
+    void unpublish_gpu_views();
 
     // --- Query ---
     std::vector<DeviceSnapshot> list_devices() const;
@@ -211,7 +232,7 @@ private:
     // --- Init helpers ---
     void init_device(const NvmeEntry& nvme, int32_t device_id);
 
-    void install_gpu_symlinks(DeviceState& dev);
+    bool install_gpu_symlinks(DeviceState& dev);
     void remove_gpu_symlinks(DeviceState& dev);
 
     // --- Reaper ---


### PR DESCRIPTION
## 中文

### 背景与核心修改

这次修改修复了 daemon 启动阶段 GPU 文件系统视图创建过早的问题。此前，`ServiceState` 在完成 B3 bring-up 后，会在设备挂载前创建 `/mnt/nvmeN/GPU<n>` 及其软链；随后挂载到 `/mnt/nvmeN` 的 ext4 文件系统会遮蔽已经创建的目录，导致 gRPC 可能向客户端返回目标不存在的软链。

本 PR 将原本隐式耦合的生命周期拆成三个明确阶段：

1. **设备初始化**：`ServiceState` 执行 B3 bring-up 并采集设备元数据；
2. **文件系统挂载**：`MountManager` 准备完整挂载点，daemon 挂载并确认文件系统可见；
3. **GPU 视图发布**：daemon 仅在已挂载的 NVMe 文件系统内创建 `GPU<n>` 目录和对应软链。

核心接口位于 `nvmeservice_state.h`，生产生命周期位于 `tutti_daemon.cpp`。

### 组件功能变更

| 组件 | 修改前 | 修改后 | 解决的问题 |
| --- | --- | --- | --- |
| `ServiceState` 构造函数 | B3 初始化控制器后立即创建 `GPU<n>` 和软链 | 只负责 B3 初始化及设备元数据采集 | 避免在挂载前创建 `/mnt/nvmeN/GPU<n>` |
| `ServiceState::publish_gpu_views()` | 不存在；GPU 视图由构造函数隐式创建 | 新增显式接口，由 daemon 在确认挂载后调用 | 将设备初始化和文件路径发布解耦 |
| `ServiceState::unpublish_gpu_views()` | 仅在析构时隐式清理 | 新增显式、幂等接口；daemon 在卸载前调用，析构函数仍执行防御性清理 | 保证清理作用于已挂载的 NVMe 文件系统 |
| GPU 视图创建逻辑 | 私有函数，无整体成功状态 | 返回 `bool`；允许部分 GPU 视图成功、部分失败 | daemon 可以记录视图发布失败 |
| `tutti_daemon` 启动流程 | 先构造 `ServiceState` 并创建目录，再执行挂载 | 先拉起设备，再挂载；确认挂载可见后才发布 GPU 视图 | 修复目录被后续挂载遮蔽的问题 |
| `tutti_daemon` 挂载失败处理 | GPU 目录和软链可能已存在，并指向宿主文件系统 | 不为未挂载设备发布 GPU 视图，RPC 中对应 `mount_path` 保持为空 | 避免客户端误用根文件系统上的假存储路径 |
| `tutti_daemon` 退出流程 | 先卸载，随后由 `ServiceState` 析构清理目录 | 先撤销 GPU 视图，再卸载，最后释放控制器 | 清理操作指向正确的 NVMe 文件系统 |
| gRPC 启动失败处理 | 已挂载设备可能没有被主动卸载 | 主动撤销 GPU 视图并调用 `unmount_all()` | 避免端口绑定失败后遗留挂载 |
| `MountManager` | 使用单层 `mkdir()`，实际依赖 `ServiceState::create_directories()` 提前创建父目录 | 自己递归创建完整挂载点，并验证结果是目录 | 明确挂载点目录的责任归属 |
| `nvmeservice_daemon` 示例 | 构造 `ServiceState` 时无条件创建 GPU 视图 | 仅对操作员已经挂载的路径发布视图 | 示例 daemon 不会在未挂载路径下创建假目录 |
| Proto/客户端注释 | 空 `mount_path` 只表示软链安装失败 | 空值表示“未挂载或视图发布失败” | 与新的生命周期语义保持一致 |
| MountManager contract | 没有覆盖多层挂载点创建 | 新增递归挂载点准备测试 | 防止拆分 `ServiceState` 后出现父目录不存在的回归 |

### 启动流程对比

| 阶段 | 修改前 | 修改后 |
| --- | --- | --- |
| 1 | 解析配置 | 解析配置 |
| 2 | `ServiceState` 对所有 NVMe 执行 B3 bring-up | `ServiceState` 对所有 NVMe 执行 B3 bring-up |
| 3 | `ServiceState` 创建 `/mnt/nvmeN/GPU<n>` | 不执行任何文件系统目录创建 |
| 4 | 创建 `/mnt/gpu<n>` 和视图软链 | `MountManager` 准备真实挂载点 |
| 5 | daemon 将 `/dev/snvmeNnX` 挂载到 `/mnt/nvmeN` | daemon 将 `/dev/snvmeNnX` 挂载到 `/mnt/nvmeN` |
| 6 | 挂载遮蔽第 3 步创建的 `GPU<n>` | 使用 `is_mounted()` 确认挂载可见 |
| 7 | 启动 gRPC，可能返回一个目标不存在的软链 | 在已挂载文件系统内创建 `GPU<n>` 和软链 |
| 8 | — | 启动 gRPC |

```text
修改前 / Before

B3 bring-up
    ↓
创建 /mnt/nvme0/GPU0
    ↓
创建 /mnt/gpu0/ssnvme0 软链
    ↓
mount /dev/snvme0n1 /mnt/nvme0
    ↓
GPU0 被遮蔽
    ↓
启动 gRPC
```

```text
修改后 / After

B3 bring-up
    ↓
准备 /mnt/nvme0 挂载点
    ↓
mount /dev/snvme0n1 /mnt/nvme0
    ↓
确认 /mnt/nvme0 是挂载点
    ↓
在 ext4 内创建 /mnt/nvme0/GPU0
    ↓
发布 /mnt/gpu0/ssnvme0 软链
    ↓
启动 gRPC
```

### 退出流程对比

| 阶段 | 修改前 | 修改后 |
| --- | --- | --- |
| 1 | 停止 gRPC 和 reaper | 停止 gRPC 和 reaper |
| 2 | 卸载 `/mnt/nvmeN` | 删除 GPU 视图软链 |
| 3 | `ServiceState` 析构 | 尝试删除空的 `GPU<n>` 目录 |
| 4 | 删除软链和 `/mnt/nvmeN/GPU<n>` | 卸载 `/mnt/nvmeN` |
| 5 | 实际操作可能落在卸载后的宿主文件系统 | `ServiceState` 析构执行幂等防御性清理 |
| 6 | 释放控制器 | 释放控制器 |

新的退出顺序在 `tutti_daemon.cpp` 中明确执行；即使 gRPC 启动失败，也会撤销已发布的视图并卸载 daemon 创建的挂载。

### 保持不变的行为

| 项目 | 状态 |
| --- | --- |
| `resolver_test` 目录及相关测试 | 未修改 |
| `/mnt/nvmeN/GPU<n>` 路径格式 | 不变 |
| `/mnt/gpu<n>/ssnvmeN` 软链格式 | 不变 |
| `allowed_gpus` ACL 检查 | 不变 |
| `auto_mount=false` 语义 | 仍要求操作员预先挂载 |
| daemon 只卸载自己创建的挂载 | 不变 |
| gRPC 字段和 wire format | 不变，仅更新空值语义说明 |
| 挂载失败后 daemon 是否继续运行 | 仍然继续，但不发布该设备的 GPU 文件系统视图 |

---

## English

### Background and core change

This PR fixes GPU filesystem views being created too early during daemon startup. Previously, `ServiceState` created `/mnt/nvmeN/GPU<n>` and its symlink immediately after B3 bring-up, before the device was mounted. Mounting the ext4 filesystem on `/mnt/nvmeN` later hid that directory, so gRPC could expose a symlink whose target did not exist.

The change splits the formerly implicit lifecycle into three explicit phases:

1. **Device initialization**: `ServiceState` performs B3 bring-up and collects device metadata.
2. **Filesystem mounting**: `MountManager` prepares the complete mount point, and the daemon mounts and verifies that the filesystem is visible.
3. **GPU view publication**: only after a successful mount does the daemon create `GPU<n>` inside the NVMe filesystem and publish the corresponding symlink.

The core API is in `nvmeservice_state.h`, and the production lifecycle is implemented in `tutti_daemon.cpp`.

### Component behavior changes

| Component | Before | After | Problem addressed |
| --- | --- | --- | --- |
| `ServiceState` constructor | Created `GPU<n>` directories and symlinks immediately after B3 controller initialization | Only performs B3 initialization and device metadata collection | Prevents `/mnt/nvmeN/GPU<n>` from being created before mount |
| `ServiceState::publish_gpu_views()` | Did not exist; construction implicitly published views | New explicit API called by the daemon after mount verification | Decouples device initialization from filesystem-path publication |
| `ServiceState::unpublish_gpu_views()` | Cleanup happened only implicitly during destruction | New explicit, idempotent API called before unmount; the destructor retains defensive cleanup | Ensures cleanup targets the mounted NVMe filesystem |
| GPU view creation | Private helper with no aggregate success status | Returns `bool` and permits partial per-GPU success | Allows the daemon to log publication failures |
| `tutti_daemon` startup | Constructed `ServiceState` and created directories before mounting | Brings devices up, mounts them, verifies visibility, and only then publishes GPU views | Prevents later mounts from hiding published directories |
| Mount failure handling | GPU directories/symlinks could already exist on the host filesystem | Does not publish a view for an unmounted device; its RPC `mount_path` remains empty | Prevents clients from using a fake storage path on the root filesystem |
| `tutti_daemon` shutdown | Unmounted first, then relied on `ServiceState` destruction to remove directories | Unpublishes views first, unmounts second, and releases controllers last | Makes cleanup operate on the correct filesystem |
| gRPC startup failure | Mounted devices might not be actively unmounted | Unpublishes GPU views and calls `unmount_all()` | Avoids leaked mounts after a port-binding/startup failure |
| `MountManager` | Used one-level `mkdir()` and effectively depended on `ServiceState::create_directories()` to create parents | Recursively creates the full mount point and verifies that it is a directory | Gives mount-point preparation clear ownership |
| `nvmeservice_daemon` example | Construction unconditionally created GPU views | Publishes views only for paths already mounted by the operator | Keeps the example daemon from creating fake directories on unmounted paths |
| Proto/client comments | Empty `mount_path` meant only symlink installation failure | Empty means “not mounted or view publication failed” | Aligns documentation with the new lifecycle semantics |
| MountManager contract | Did not cover nested mount-point creation | Adds a recursive mount-point preparation test | Prevents missing-parent regressions after separating `ServiceState` responsibilities |

### Startup lifecycle

| Phase | Before | After |
| --- | --- | --- |
| 1 | Parse configuration | Parse configuration |
| 2 | `ServiceState` performs B3 bring-up for every NVMe device | `ServiceState` performs B3 bring-up for every NVMe device |
| 3 | `ServiceState` creates `/mnt/nvmeN/GPU<n>` | No filesystem directories are created |
| 4 | Create `/mnt/gpu<n>` and the view symlink | `MountManager` prepares the real mount point |
| 5 | Mount `/dev/snvmeNnX` on `/mnt/nvmeN` | Mount `/dev/snvmeNnX` on `/mnt/nvmeN` |
| 6 | The mount hides the `GPU<n>` directory created in phase 3 | Confirm visibility with `is_mounted()` |
| 7 | Start gRPC, potentially exposing a symlink with a missing target | Create `GPU<n>` and its symlink inside the mounted filesystem |
| 8 | — | Start gRPC |

### Shutdown lifecycle

| Phase | Before | After |
| --- | --- | --- |
| 1 | Stop gRPC and the reaper | Stop gRPC and the reaper |
| 2 | Unmount `/mnt/nvmeN` | Remove GPU view symlinks |
| 3 | Destroy `ServiceState` | Attempt to remove empty `GPU<n>` directories |
| 4 | Remove symlinks and `/mnt/nvmeN/GPU<n>` | Unmount `/mnt/nvmeN` |
| 5 | Cleanup could affect the host filesystem after unmount | `ServiceState` destruction performs idempotent defensive cleanup |
| 6 | Release controllers | Release controllers |

The new shutdown order is explicit in `tutti_daemon.cpp`. The same cleanup path runs if gRPC startup fails: published views are withdrawn and daemon-owned mounts are unmounted.

### Intentionally unchanged behavior

| Item | Status |
| --- | --- |
| `resolver_test` directory and related tests | Unchanged |
| `/mnt/nvmeN/GPU<n>` path format | Unchanged |
| `/mnt/gpu<n>/ssnvmeN` symlink format | Unchanged |
| `allowed_gpus` ACL enforcement | Unchanged |
| `auto_mount=false` semantics | Still requires operator-managed pre-mounting |
| Daemon unmount ownership | The daemon still unmounts only mounts it created |
| gRPC fields and wire format | Unchanged; only the empty-value documentation is updated |
| Behavior after a mount failure | The daemon still continues, but does not publish that device's GPU filesystem view |

## 验证 / Validation

```bash
cmake --preset host
cmake --build --preset host --target tutti_mount_manager_contract_test --parallel 8
ctest --test-dir build/host -R '^tutti_mount_manager_contract_test$' --output-on-failure
```

Result: **1/1 test passed**. The contract now verifies recursive preparation of a nested mount point even when the subsequent block-device mount intentionally fails.

