### PR TITLE
feat: add MACA adaption for host PRP page

### DIFF
--- a/tutti/data_paths/local_nvme/metadata/prp_page_cache.cpp
+++ b/tutti/data_paths/local_nvme/metadata/prp_page_cache.cpp
@@ -33,6 +33,22 @@ bool PrpPageCache::init(const Config& cfg, nvm_ctrl_t* ctrl) {
 #if defined(TUTTI_USE_HOST)
     std::fprintf(stderr, "[prp_cache] init: HOST profile has no pinned-host allocator\n");
     return false;
+#elif defined(TUTTI_USE_MACA)
+    // MACA cudaHostAlloc page can't get user page for its own memory framework
+    int ret = posix_memalign(&pool_host_, 8192, bytes);
+    if (ret != 0) {
+        std::fprintf(stderr,
+                     "[prp_cache] init: posix_memalign(%zu bytes) failed\n", bytes);
+        return false;
+    }
+    cudaError_t ce = cudaHostRegister(pool_host_, bytes, mcHostRegisterDefault);
+    if (ce != cudaSuccess) {
+        std::fprintf(stderr,
+                     "[prp_cache] init: cudaHostRegister(%zu bytes) failed: %s\n",
+                     bytes, cudaGetErrorString(ce));
+        free(pool_host_);
+        return false;
+    }
 #else
     cudaError_t ce = cudaHostAlloc(&pool_host_, bytes, cudaHostAllocDefault);
     if (ce != cudaSuccess || pool_host_ == nullptr) {
@@ -46,9 +62,14 @@ bool PrpPageCache::init(const Config& cfg, nvm_ctrl_t* ctrl) {
     int rc = nvm_dma_map_data_host(&pool_dma_, ctrl, pool_host_, bytes);
     if (rc != 0 || pool_dma_ == nullptr) {
         std::fprintf(stderr,
-                     "[prp_cache] init: nvm_dma_map_data_host failed: rc=%d\n",
-                     rc);
+                     "[prp_cache] init: nvm_dma_map_data_host failed: rc=%d pool=%p\n",
+                     rc, pool_host_);
+#if defined(TUTTI_USE_MACA)
+        cudaHostUnregister(pool_host_);
+        free(pool_host_);
+#else
         cudaFreeHost(pool_host_);
+#endif
         pool_host_ = nullptr;
         return false;
     }
@@ -77,7 +98,12 @@ void PrpPageCache::shutdown() {
         pool_dma_ = nullptr;
     }
     if (pool_host_) {
+#if defined(TUTTI_USE_MACA)
+        cudaHostUnregister(pool_host_);
+        free(pool_host_);
+#else
         cudaFreeHost(pool_host_);
+#endif
         pool_host_ = nullptr;
     }
 

--- a/tutti/device_manager/nvme/kernel_modules/snvme/ctrl.c
+++ b/tutti/device_manager/nvme/kernel_modules/snvme/ctrl.c
@@ -57,7 +57,9 @@ void ctrl_put(struct ctrl* ctrl)
          * NOT wait for in-flight references to drop.  The actual
          * kfree(ctrl) is deferred to ctrl_cdev_release(), which fires
          * when the last kobject reference to ctrl->cdev.kobj is
-         * released (e.g. after all open file descriptors are closed).
+         * released (e.g. after all open file descriptors are closed)
+         * and which first purges any VFS inode still attached to
+         * ctrl->cdev.list (see the comment there).
          */
     }
 }
@@ -116,13 +118,58 @@ struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* ino
  * ALL kobject references to ctrl->cdev are dropped (including those
  * held by still-open file descriptors).  This callback is invoked
  * after cdev_del() + the final kobject_put(), guaranteeing that no
- * thread can access ctrl through the cdev or its kobj anymore.
+ * thread can access ctrl through the cdev or its kobj anymore --
+ * with ONE exception, which is exactly the bug this handler must
+ * defend against:
+ *
+ * VFS char-device inodes cache the cdev pointer in inode->i_cdev
+ * and link themselves onto cdev->list through inode->i_devices
+ * (chrdev_open).  That link is undone at inode eviction time
+ * (cd_forget: list_del_init + i_cdev = NULL), which can run AFTER
+ * the cdev kobject refcount already hit zero -- e.g. __fput does
+ * cdev_put() first and dput() (-> inode eviction -> cd_forget)
+ * afterwards.  kfree()ing ctrl while such an inode is still linked
+ * makes the later cd_forget write into the freed cdev.list, which
+ * shows up as SLUB "Poison overwritten" on the 16 bytes of
+ * cdev.list (observed as ctrl+0xC0 corruption).
+ *
+ * The kernel's own ktype_cdev_default / cdev_dynamic_release
+ * handlers solve this with cdev_purge(): before freeing they walk
+ * cdev->list and detach every inode.  ctrl_chrdev_create() swaps in
+ * this custom ktype, so the stock purge never runs; replicate it
+ * here.  cdev_purge() itself is static and relies on the
+ * unexported cdev_lock; replicating it WITHOUT the lock is safe at
+ * this point because:
+ *   - kobj refcount == 0 means no open file holds this cdev, and
+ *     cdev_del() already unmapped us from cdev_map, so no NEW inode
+ *     can attach (chrdev_open only attaches after a successful
+ *     kobj_lookup);
+ *   - a concurrent cd_forget() on a still-attached inode and our
+ *     list_del_init() both write the same self-pointers, and
+ *     inodes are RCU-freed (destroy_inode -> call_rcu), so any
+ *     inode grabbed in this non-sleeping loop stays valid memory
+ *     until we are done.
  */
 static void ctrl_cdev_release(struct kobject *kobj)
 {
 
     struct ctrl *ctrl = container_of(kobj, struct ctrl, cdev.kobj);
     printk(KERN_INFO "ctrl_cdev_release %s %p\n", ctrl->name, (void *)kobj);
+
+    /*
+     * Replicate cdev_purge(): detach every inode still hanging off
+     * ctrl->cdev.list so its later eviction (cd_forget) cannot
+     * write into the memory we are about to free.  After this loop,
+     * any such inode's i_devices is self-pointing, so a future
+     * list_del_init() only touches the inode itself.
+     */
+    while (!list_empty(&ctrl->cdev.list)) {
+        struct inode *inode = container_of(ctrl->cdev.list.next,
+                                           struct inode, i_devices);
+        list_del_init(&inode->i_devices);
+        inode->i_cdev = NULL;
+    }
+
     kfree(ctrl->user_qid_bitmap);
     ctrl->user_qid_bitmap = NULL;
     mutex_destroy(&ctrl->user_qid_lock);

--- a/tutti/device_manager/nvme/kernel_modules/snvme/snvm_control.c
+++ b/tutti/device_manager/nvme/kernel_modules/snvme/snvm_control.c
@@ -74,6 +74,9 @@ int snvm_chrdev_create(struct pci_dev *pdev, unsigned int class){
 
 	ctrl = ctrl_get(&ctrl_list, dev_class, pdev, minor);
 	if (IS_ERR(ctrl)) {
+		/* kmalloc failed: ctrl never entered ctrl_list and owns
+		 * nothing, but the minor was already taken from the IDA. */
+		ida_simple_remove(&snvm_chrdev_minor_ida, minor);
 		return PTR_ERR(ctrl);
 	}
 	err = ctrl_chrdev_create(ctrl, dev_first, &snvm_dev_fops);


### PR DESCRIPTION
- add MACA path using posix_memalign + cudaHostRegister/Unregister for host PRP page
- fix use-after-free in ctrl_cdev_release — replicate cdev_purge() to detach cached VFS inodes from cdev.list before kfree(ctrl), preventing SLUB "Poison overwritten" on cdev.list caused by late cd_forget writing freed memory
```mermaid
sequenceDiagram
    participant P as process exit (pid 40740)
    participant V as VFS
    participant S as snvme 
    participant Sl as SLUB

    Note over P,Sl:  before (BUG)
    P->>V: __fput(fd)
    V->>S: cdev_put → kobject_put → ctrl_cdev_release
    S->>Sl: kfree(ctrl) — inode still in cdev.list!
    V->>S: dput → evict_inode → cd_forget(inode)
    S->>Sl: list_del_init write freed cdev.list (UAF)
    Sl-->>Sl: Poison overwritten @ctrl+0xC0

    Note over P,Sl: after
    P->>V: __fput(fd)
    V->>S: cdev_put → kobject_put → ctrl_cdev_release
    S->>S:  unlocked cdev_purge(): i_cdev=NULL +  clear inode list
    S->>Sl: kfree(ctrl) 
    V->>S: dput → evict_inode →  evict
    S->>S:  i_cdev==NULL skip (cd_forget(inode))
```



- fix IDA minor leak when ctrl_get() fails


